### PR TITLE
Expose module versions on API

### DIFF
--- a/Api/ModuleInfoInterface.php
+++ b/Api/ModuleInfoInterface.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Marketplacer\Base\Api;
+
+interface ModuleInfoInterface
+{
+    /**
+     * Retrieving a list of modules
+     *
+     * @return mixed
+     */
+    public function getList(): array;
+}

--- a/Model/ModuleInfo.php
+++ b/Model/ModuleInfo.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+namespace Marketplacer\Base\Model;
+
+use Magento\Framework\Component\ComponentRegistrarInterface;
+use Magento\Framework\Filesystem\Directory\ReadFactory;
+use Magento\Framework\Module\ModuleList;
+use Marketplacer\Base\Api\ModuleInfoInterface;
+use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Serialize\Serializer\Json;
+use Marketplacer\Base\Model\ModuleInfo\ModuleInfoConfig;
+use \Throwable;
+
+class ModuleInfo implements ModuleInfoInterface
+{
+    /**
+     * @param ModuleList $moduleList
+     * @param ComponentRegistrarInterface $componentRegistrar
+     * @param ReadFactory $readFactory
+     * @param Json $json
+     * @param ModuleInfoConfig $moduleInfoConfig
+     */
+    public function __construct(
+        private ModuleList $moduleList,
+        private ComponentRegistrarInterface $componentRegistrar,
+        private ReadFactory $readFactory,
+        private Json $json,
+        private ModuleInfoConfig $moduleInfoConfig
+    ) {
+    }
+
+    /**
+     * Retrieving a list of modules
+     *
+     * @return array
+     */
+    public function getList(): array
+    {
+        $listModules = $this->moduleList->getNames();
+        $results = [];
+        foreach ($listModules as $name) {
+            $moduleInfo = $this->getModuleInfo($name);
+            $moduleInfo['name'] = $name;
+            $results[] = $moduleInfo;
+
+        }
+        return $results;
+    }
+
+    /**
+     * Get info about the module
+     *
+     * @param string $moduleName
+     * @return array
+     */
+    private function getModuleInfo(string $moduleName): array
+    {
+        $path = $this->componentRegistrar->getPath(
+            ComponentRegistrar::MODULE,
+            $moduleName
+        );
+        $directoryRead = $this->readFactory->create($path);
+        try {
+            $composerJsonData = $directoryRead->readFile('composer.json');
+            $data = $this->json->unserialize($composerJsonData);
+        } catch (Throwable $exception) {
+            return [];
+        }
+
+        return [
+            'version' => !empty($data['version']) ? $data['version'] : $this->moduleInfoConfig->getVersion($moduleName)
+        ];
+    }
+}

--- a/Model/ModuleInfo/Config/Converter.php
+++ b/Model/ModuleInfo/Config/Converter.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Marketplacer\Base\Model\ModuleInfo\Config;
+
+use Magento\Framework\Config\ConverterInterface;
+
+class Converter implements ConverterInterface
+{
+    /**
+     * Convert config
+     *
+     * @param \DOMDocument $source
+     * @return array
+     */
+    public function convert($source): array
+    {
+        $output = [];
+
+        /** @var \DOMElement $module */
+        foreach ($source->getElementsByTagName('module') as $module) {
+            $name = $module->getAttribute('name');
+            $output[$name] = [
+                'version' => $module->getElementsByTagName('version')->item(0)->textContent
+            ];
+        }
+
+        return $output;
+    }
+}

--- a/Model/ModuleInfo/ModuleInfoConfig.php
+++ b/Model/ModuleInfo/ModuleInfoConfig.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Marketplacer\Base\Model\ModuleInfo;
+
+use Magento\Framework\Config\Data;
+
+class ModuleInfoConfig extends Data
+{
+    /**
+     * Retrieve the module version
+     *
+     * @param string $moduleName
+     * @return ?string
+     */
+    public function getVersion(string $moduleName): ?string
+    {
+        return $this->get($moduleName. '/version');
+    }
+}

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -3,7 +3,9 @@
     <acl>
         <resources>
             <resource id="Magento_Backend::admin">
-                <resource id="Marketplacer_Base::marketplacer" title="Marketplacer" sortOrder="200"/>
+                <resource id="Marketplacer_Base::marketplacer" title="Marketplacer" sortOrder="200">
+                    <resource id="Marketplacer_Base::base_api" title="Base API managements" translate="title" sortOrder="10"/>
+                </resource>
                 <resource id="Magento_Backend::stores">
                     <resource id="Magento_Backend::stores_settings">
                         <resource id="Magento_Config::config">

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="Marketplacer\Base\Api\CacheInvalidatorInterface" type="Marketplacer\Base\Model\CacheInvalidator"/>
+    <preference for="Marketplacer\Base\Api\ModuleInfoInterface" type="Marketplacer\Base\Model\ModuleInfo"/>
 
     <!-- default cache types to be invalidated -->
     <type name="Marketplacer\Base\Model\CacheInvalidator">
@@ -9,6 +10,28 @@
                 <item name="block_html" xsi:type="string">block_html</item>
                 <item name="full_page" xsi:type="string">full_page</item>
             </argument>
+        </arguments>
+    </type>
+
+    <virtualType name="Marketplacer\Base\Model\ModuleInfo\Config\SchemaLocator" type="Magento\Framework\Config\SchemaLocator">
+        <arguments>
+            <argument name="realPath" xsi:type="string">urn:magento:module:Marketplacer_Base:etc/module_info.xsd</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="Marketplacer\Base\Model\ModuleInfo\Config\Reader" type="Magento\Framework\Config\Reader\Filesystem">
+        <arguments>
+            <argument name="converter" xsi:type="object">Marketplacer\Base\Model\ModuleInfo\Config\Converter</argument>
+            <argument name="schemaLocator" xsi:type="object">Marketplacer\Base\Model\ModuleInfo\Config\SchemaLocator</argument>
+            <argument name="fileName" xsi:type="string">module_info.xml</argument>
+            <argument name="idAttributes" xsi:type="array">
+                <item name="/config/module" xsi:type="string">name</item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <type name="Marketplacer\Base\Model\ModuleInfo\ModuleInfoConfig">
+        <arguments>
+            <argument name="cacheId" xsi:type="string">module_info_cache</argument>
+            <argument name="reader" xsi:type="object">Marketplacer\Base\Model\ModuleInfo\Config\Reader</argument>
         </arguments>
     </type>
 </config>

--- a/etc/module_info.xml
+++ b/etc/module_info.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Marketplacer_Base:etc/module_info.xsd">
+    <module name="Marketplacer_Base">
+        <version>2.1.0</version>
+    </module>
+</config>

--- a/etc/module_info.xsd
+++ b/etc/module_info.xsd
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="config">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="unbounded" name="module" type="moduleInfo" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:complexType name="moduleInfo">
+        <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="version" type="xs:string" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+</xs:schema>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
+    <!-- Brand -->
+    <route url="/V1/module/list" method="GET">
+        <service class="Marketplacer\Base\Api\ModuleInfoInterface" method="getList"/>
+        <resources>
+            <resource ref="Marketplacer_Base::base_api"/>
+        </resources>
+    </route>
+</routes>


### PR DESCRIPTION
Release 2.1.0 publishing

## Checklist

- [ ] Cross-browser testing
- [ ] Deployed to an environment
- [ ] PR has appropriate labels added (needs-testing, etc.)
- [ ] Authentication is on point (you are who you say you are)
- [ ] Authorisation is on point (you are allowed to access this)
- [ ] Data and input/output validation controls (SQL injection, XSS attacks, file validation, type conversion)
- [ ] Error and exception handling controls (transaction rollbacks, parsing external errors)
- [ ] Any newly introduced PII or confidential data is appropriately handled.  This includes external systems like Rollbar and Datadog, but also applies internally to Dupliplacer, Umbrella_Placer and the like.
- [ ] Any schema changes have been notified to the data platform team in #data-change-notifications on slack.
- [ ] Aware of the downstream/upstream effects this change will have. The Marketplacer ecosystem is beyond complicated and now has many system dependencies.  Take the time to understand how your change interacts with them and speak to some teams if you need to (MConnect, Cerberus, Graphql, API V2, Headless, Connected, Fullstack, Minsights, Umbrella_Placer, Spreadsheet Uploaders, MStores, MultiStores, and more!)
- [ ] Supporting documentation published. A release is not just pushing a code change, it's also communicating it.
In-App documentation, Knowledgebase, API Docs, Tettra Docs, Postman Collection, Lucid Charts, and your PM knows what's up.

**See:** https://app.tettra.co/teams/marketplacer/pages/system-acquisition-and-development-policy
**See:** https://app.tettra.co/teams/marketplacer/pages/threat-modelling
